### PR TITLE
Ensure diagnostics screenshot directory is created before capture

### DIFF
--- a/diagnostics.py
+++ b/diagnostics.py
@@ -46,6 +46,15 @@ def take_diagnostic_screenshots(scenario_name, step_index):
     :return: A list of paths to the saved screenshots.
     """
     log_action("Taking diagnostic screenshots...")
+    try:
+        os.makedirs(SCREENSHOTS_DIR, exist_ok=True)
+    except OSError as e:
+        log_action(
+            f"Unable to ensure screenshots directory '{SCREENSHOTS_DIR}': {e}",
+            is_error=True,
+        )
+        return []
+
     paths = []
     base_filename = f"{scenario_name}_step_{step_index + 1}_failure"
 


### PR DESCRIPTION
## Summary
- create the reports/screenshots directory before taking diagnostics screenshots
- log an explicit error and skip captures when the directory cannot be created

## Testing
- python - <<'PY'
import shutil
import os
import types
import sys

fake_pyautogui = types.SimpleNamespace()

def fake_screenshot(path):
    with open(path, 'w') as f:
        f.write('fake screenshot')

fake_pyautogui.screenshot = fake_screenshot
sys.modules['pyautogui'] = fake_pyautogui

fake_psutil = types.SimpleNamespace(
    cpu_percent=lambda interval=1: 0,
    virtual_memory=lambda: types.SimpleNamespace(percent=0)
)
sys.modules['psutil'] = fake_psutil

import diagnostics

diagnostics.log_action = lambda message, is_error=False: print(('ERROR: ' if is_error else '') + message)

shutil.rmtree('reports', ignore_errors=True)

paths = diagnostics.take_diagnostic_screenshots('demo_scenario', 0)
print('paths:', paths)
print('all_exist:', all(os.path.exists(p) for p in paths))
print('base_dir_exists:', os.path.isdir(diagnostics.SCREENSHOTS_DIR))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e15e3810b4832d95e3ee2391e25c86